### PR TITLE
Adding partitionID for SciFi

### DIFF
--- a/unpack.py
+++ b/unpack.py
@@ -19,7 +19,7 @@ def main():
             ROOT.PixelUnpack(0x0800),
             ROOT.PixelUnpack(0x0801),
             ROOT.PixelUnpack(0x0802),
-            ROOT.SciFiUnpack(),
+            ROOT.SciFiUnpack(0x0900),
         ]
 
     for unpacker in unpackers:


### PR DESCRIPTION
Dear Oliver,

trying to run the unpacker on SciFi raw data lead to an error of missing argument. 
After discussing it with Ana Barbara ( @anabarbararc ), it should be added the partitionID when calling the unpacker class.

Now it seems to work, I will keep you updated.
Best regards,
Antonio