### PR TITLE
adding partitionID to SciFi unpacker

### DIFF
--- a/unpack.py
+++ b/unpack.py
@@ -18,7 +18,7 @@ def main():
         source.AddUnpacker(0x800, pixelUnpack)
         source.AddUnpacker(0x801, pixelUnpack)
         source.AddUnpacker(0x802, pixelUnpack)
-        source.AddUnpacker(0x900, ROOT.SciFiUnpack())
+        source.AddUnpacker(0x900, ROOT.SciFiUnpack(0x900))
 
     run = ROOT.FairRunOnline(source)
     run.SetOutputFile(args.output)


### PR DESCRIPTION
SciFiUnpack() constructor requires partitionID as option,
otherwise we get the error:

Traceback (most recent call last):
  File "/afs/cern.ch/work/a/aiuliano/public/oliver_online/unpack.py", line 45, in <module>
    main()
  File "/afs/cern.ch/work/a/aiuliano/public/oliver_online/unpack.py", line 21, in main
    source.AddUnpacker(0x900, ROOT.SciFiUnpack())
TypeError: SciFiUnpack::SciFiUnpack(unsigned short PartitionId) =>
    takes at least 1 arguments (0 given)
[INFO] PixelUnpack: Delete instance


This should fix that.
Best regards,
Antonio